### PR TITLE
Hotfix sass class not working

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -298,8 +298,6 @@ module.exports = {
             use: getStyleLoaders(
               {
                 importLoaders: 2,
-                modules: true,
-                getLocalIdent: getCSSModuleLocalIdent,
               },
               'sass-loader'
             ),

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,4 +1,4 @@
 import React from 'react';
-import './dashboard.module.scss';
-const Dashboard = () => <div className="dasher">I'm a dashboard</div>;
+import styles from './dashboard.module.scss';
+const Dashboard = () => <div className={styles.dasher}>I'm a dashboard</div>;
 export default Dashboard;

--- a/src/components/dashboard.module.scss
+++ b/src/components/dashboard.module.scss
@@ -1,6 +1,6 @@
 body {
     color: red;
 }
-.dasher {
+:local(.dasher) {
     color: blue
 }


### PR DESCRIPTION
Resolves https://github.com/ascasson/super-duper-job-board/issues/34

**What have I done?**:
- scoped `.dasher` class to local
- created named import for `dashboard.module.scss` as `styles`
- applied module based css class to `.dasher` element
- removed unnecessary css module statements from `sass-loader` config, since by itself it doesn't support css-modules (this is a feature of `css-loader` -> setting `modules: true` there is enough for it to work)

**What's going on here?**

Webpack's `css-loader` is set to use `modules: true`, meaning it will transform css-classes within your `<style>` declarations to local module classes per default. However this won't be applied to your elements class attribute, since the ´css-loader´ can't touch it. For this to work, you'll have to

- apply a scope `:local(.myClass)` or `:global(.myClass)` in your `.scss` file 
- import `.css` or `.scss` files as modules (named import)
- apply the classes itself in object notation to their respective elements i.e. `class={styles.myClass}`

Last but not least css modules are a feature of the `css-loader`, not the `sass-loader`. So there's actually no need for the `sass-loader` to use those options in the webpack config.

Find out more about this behavior here:
- https://javascriptplayground.com/css-modules-webpack-react/
- https://github.com/webpack-contrib/sass-loader/issues/448 