### PR TITLE
Add build and test commands to travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
         - "8"
+install:
+  - npm install
+script:
+  - npm run-script build
+  - npm test


### PR DESCRIPTION
This PR is a continuation of the work done in https://github.com/ascasson/super-duper-job-board/pull/39

I have added ```npm install``` in install phase, and ```npm run-script build``` and ```npm test``` in script phase.